### PR TITLE
fix: rename gnu→gnu_omp variant and add stdlib(c) for Intel glibc

### DIFF
--- a/.ci_support/linux_64_is_intelfalserunner_variantgnuwith_mpifalse.yaml
+++ b/.ci_support/linux_64_is_intelfalserunner_variantgnuwith_mpifalse.yaml
@@ -27,7 +27,7 @@ liblapack:
 openmpi:
 - '5'
 runner_variant:
-- gnu
+- gnu_omp
 target_platform:
 - linux-64
 with_mpi:

--- a/.ci_support/linux_64_is_inteltruerunner_variantintelwith_mpifalse.yaml
+++ b/.ci_support/linux_64_is_inteltruerunner_variantintelwith_mpifalse.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 c_stdlib:
 - sysroot
 c_stdlib_version:
-- '2.17'
+- '2.28'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -38,3 +38,4 @@ zip_keys:
 - - runner_variant
   - is_intel
   - with_mpi
+  - c_stdlib_version

--- a/.ci_support/osx_64_is_intelfalserunner_variantgnuwith_mpifalse.yaml
+++ b/.ci_support/osx_64_is_intelfalserunner_variantgnuwith_mpifalse.yaml
@@ -33,7 +33,7 @@ macos_machine:
 openmpi:
 - '5'
 runner_variant:
-- gnu
+- gnu_omp
 target_platform:
 - osx-64
 with_mpi:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,5 +1,5 @@
 runner_variant:
-  - gnu
+  - gnu_omp
   - gnu_mpi
   - intel
 
@@ -13,7 +13,13 @@ with_mpi:
   - true
   - false
 
+c_stdlib_version:    # [linux]
+  - "2.17"           # [linux]
+  - "2.17"           # [linux]
+  - "2.28"           # [linux]
+
 zip_keys:
   - - runner_variant
     - is_intel
     - with_mpi
+    - c_stdlib_version  # [linux]

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -24,13 +24,13 @@ requirements:
     - cmake
     - make
     - m4
+    - ${{ stdlib('c') }}
     - if: is_intel
       then:
         - ifx_linux-64
         - dpcpp_linux-64
       else:
         - ${{ compiler('c') }}
-        - ${{ stdlib('c') }}
         - ${{ compiler('fortran') }}
 
   host:
@@ -112,7 +112,7 @@ about:
 
     Three build variants are provided under the single package name ``runner``:
 
-    gnu
+    gnu_omp
       GCC/gfortran, OpenBLAS, serial only.  Linux and macOS.
 
     gnu_mpi
@@ -123,7 +123,7 @@ about:
 
     Select a specific variant with a build-string glob, e.g.::
 
-      conda install "runner=*=gnu_*"   # GNU serial
+      conda install "runner=*=gnu_omp_*"   # GNU serial
       conda install "runner=*=gnu_mpi_*"   # GNU parallel
       conda install "runner=*=intel_*"   # Intel serial
 


### PR DESCRIPTION
## Summary

Fixes two reported build issues:

### 1. GNU/OMP variant resolves to MPI at install time

The `gnu` variant's build string (`gnu_h…`) is a prefix of `gnu_mpi_h…`, so `conda install "runner=*=gnu_*"` matches **both** variants. Renamed `gnu` → `gnu_omp` to make the globs unambiguous.

### 2. Intel variant linked to wrong glibc

`${{ stdlib('c') }}` was only in the GNU branch of the compiler conditional. The Intel build:
- Used system glibc 2.34 (Alma 9 Docker image) instead of the conda-forge sysroot
- Produced a package with **no `__glibc` constraint** in the metadata

Fix: moved `stdlib('c')` outside the conditional and set `c_stdlib_version=2.28` for Intel (required by `ifx_linux-64`).

## Changes

- `recipe/recipe.yaml` — moved `stdlib('c')` before the compiler conditional; updated variant description
- `recipe/conda_build_config.yaml` — `gnu` → `gnu_omp`; added per-variant `c_stdlib_version` with zip_keys
- `.ci_support/` — updated `runner_variant` and `c_stdlib_version` in affected configs

## Verification

All three Linux variants rebuilt and tested successfully with `rattler-build`:

| Variant | Build string | `__glibc` | Tests |
|---------|-------------|-----------|-------|
| gnu_omp | `gnu_omp_h6d0f835_1` | `>=2.17` | ✔ |
| gnu_mpi | `gnu_mpi_h1733be7_1` | `>=2.17` | ✔ |
| intel | `intel_h6facef5_1` | `>=2.28` | ✔ |


